### PR TITLE
remove unused variables in eval.hs

### DIFF
--- a/src/Language/Elsa/Eval.hs
+++ b/src/Language/Elsa/Eval.hs
@@ -220,8 +220,6 @@ bSubst :: Expr a -> Id -> Expr a -> Expr a
 bSubst e x e' = subst e (M.singleton x e'')
   where
     e''       = e' -- alphaShift n e'
-    n         = 1 + maximum (0 : mapMaybe isAId vs)
-    vs        = S.toList (freeVars e')
 
 --------------------------------------------------------------------------------
 -- | General Helpers


### PR DESCRIPTION
During build `stack` complains of unused variables.
```
./elsa/src/Language/Elsa/Eval.hs:223:5: Warning: Defined but not used: ‘n’
./elsa/src/Language/Elsa/Eval.hs:224:5: Warning: Defined but not used: ‘vs’
```