### PR TITLE
check duplicate identifiers

### DIFF
--- a/src/Language/Elsa/Eval.hs
+++ b/src/Language/Elsa/Eval.hs
@@ -33,10 +33,14 @@ mkEnv :: [Defn a] -> CheckM a (Env a)
 mkEnv = foldM expand M.empty
 
 expand :: Env a -> Defn a -> CheckM a (Env a)
-expand g (Defn b e) = case zs of
-                        (x,l) : _ -> Left  (Unbound b x l)
-                        []        -> Right (M.insert (bindId b) e' g)
+expand g (Defn b e) = 
+  if dupId 
+    then Left (errDupDefn b)
+    else case zs of
+      (x,l) : _ -> Left  (Unbound b x l)
+      []        -> Right (M.insert (bindId b) e' g)
   where
+    dupId           = M.member (bindId b) g
     e'              = subst e g
     zs              = M.toList (freeVars' e')
 

--- a/src/Language/Elsa/Types.hs
+++ b/src/Language/Elsa/Types.hs
@@ -30,6 +30,8 @@ data Result a
   | Partial (Bind a)    a
   | Invalid (Bind a)    a
   | Unbound (Bind a) Id a
+  | DupDefn (Bind a)    a
+  | DupEval (Bind a)    a
   deriving (Eq, Show, Functor)
 
 failures :: [Result a] -> [Id]
@@ -38,6 +40,8 @@ failures = mapMaybe go
     go (Partial b _)   = Just (bindId b)
     go (Invalid b _)   = Just (bindId b)
     go (Unbound b _ _) = Just (bindId b)
+    go (DupDefn b _)   = Just (bindId b)
+    go (DupEval b _)   = Just (bindId b)
     go _               = Nothing
 
 successes :: [Result a] -> [Id]
@@ -50,6 +54,8 @@ resultError :: (Located a) => Result a -> Maybe UserError
 resultError (Partial b l)   = mkErr l (bindId b ++ " can be further reduced!")
 resultError (Invalid b l)   = mkErr l (bindId b ++ " has an invalid reduction!")
 resultError (Unbound b x l) = mkErr l (bindId b ++ " has an unbound variable " ++ x )
+resultError (DupDefn b l)   = mkErr l ("Definition " ++ (bindId b) ++ " has already been declared")
+resultError (DupEval b l)   = mkErr l ("Eval " ++ (bindId b) ++ " has already been declared")
 resultError _               = Nothing
 
 mkErr :: (Located a) => a -> Text -> Maybe UserError

--- a/src/Language/Elsa/Types.hs
+++ b/src/Language/Elsa/Types.hs
@@ -55,7 +55,7 @@ resultError (Partial b l)   = mkErr l (bindId b ++ " can be further reduced!")
 resultError (Invalid b l)   = mkErr l (bindId b ++ " has an invalid reduction!")
 resultError (Unbound b x l) = mkErr l (bindId b ++ " has an unbound variable " ++ x )
 resultError (DupDefn b l)   = mkErr l ("Definition " ++ (bindId b) ++ " has already been declared")
-resultError (DupEval b l)   = mkErr l ("Eval " ++ (bindId b) ++ " has already been declared")
+resultError (DupEval b l)   = mkErr l ("Evaluation " ++ (bindId b) ++ " has already been declared")
 resultError _               = Nothing
 
 mkErr :: (Located a) => a -> Text -> Maybe UserError

--- a/tests/dupdefn/dup_defn.lc
+++ b/tests/dupdefn/dup_defn.lc
@@ -1,0 +1,6 @@
+let true  = \x y -> y
+let true  = \x y -> x
+
+eval test_true:
+    true x y
+    =~> x

--- a/tests/dupdefn/dup_defn_eval.lc
+++ b/tests/dupdefn/dup_defn_eval.lc
@@ -1,0 +1,10 @@
+let true  = \x y -> y
+let true  = \x y -> x
+
+eval test_true:
+    true x y
+    =~> x
+
+eval test_true:
+    true x y
+    =~> x

--- a/tests/dupeval/dup_eval.lc
+++ b/tests/dupeval/dup_eval.lc
@@ -1,0 +1,10 @@
+let id   = \x -> x
+
+eval id_x :
+  id x
+  =d> (\x -> x) x
+  =b> x
+
+eval id_x :
+  id x
+  =~> x

--- a/tests/ok/fix.lc
+++ b/tests/ok/fix.lc
@@ -42,7 +42,6 @@ let SUB   = \n m -> m DECR n
 let EQL   = \n m -> AND (ISZ (SUB n m)) (ISZ (SUB m n))
 let ADD   = \n m -> n INCR m
 let MUL   = \n m -> n (ADD m) ZERO 
-let ISZ   = \n -> n (\z -> FALSE) TRUE 
 
 --------------------------------------------------------------------------------
 -- RECURSION 
@@ -65,7 +64,7 @@ eval sum_three :
   SUM THREE 
   =~> SIX 
 
-eval fac_three : 
+eval fac_two : 
   FAC TWO 
   =~> TWO 
 


### PR DESCRIPTION
resolve issue #11 

- add and check two error types `DupDefn` and `DupEval`
- add test cases for duplicate definitions and evaluations