### PR TITLE
Add line and column numbers for parse errors

### DIFF
--- a/src/Language/Elsa/Parser.hs
+++ b/src/Language/Elsa/Parser.hs
@@ -25,14 +25,25 @@ parse = parseWith elsa
 
 parseWith  :: Parser a -> FilePath -> Text -> a
 parseWith p f s = case runParser (whole p) f s of
-                    Left pErrs -> Ex.throw (mkErrors pErrs) -- panic (show err) (posSpan . NE.head . errorPos $ err)
+                    Left pErrs -> Ex.throw (mkErrors pErrs s) -- panic (show err) (posSpan . NE.head . errorPos $ err)
                     Right e  -> e
 
-
-mkErrors :: ParseErrorBundle Text SourcePos -> [UserError]
-mkErrors b = [ mkError (parseErrorPretty e) (sp b) | e <- NE.toList (bundleErrors b)]
+mkErrors :: ParseErrorBundle Text SourcePos -> Text -> [UserError]
+mkErrors b s = [ mkError (formatLineCol e s ++ " " ++ parseErrorPretty e) (sp b) | e <- NE.toList (bundleErrors b)]
   where 
     sp     = posSpan . pstateSourcePos . bundlePosState
+
+-- PosState looks relevant for finding line/column, but I (Justin) don't know how to use it
+
+formatLineCol :: ParseError Text SourcePos -> Text -> String
+formatLineCol e s = "line " ++ show l ++ " col " ++ show c
+  where
+    (l, c) = lineCol s (errorOffset e)
+
+lineCol :: String -> Int -> (Int, Int)
+lineCol s i = foldl f (1, 1) (Prelude.take i s)
+  where
+    f (r, c) char = if char == '\n' then (r + 1, 1) else (r, c + 1)
 
 instance ShowErrorComponent SourcePos where
   showErrorComponent = show

--- a/src/Language/Elsa/Parser.hs
+++ b/src/Language/Elsa/Parser.hs
@@ -29,14 +29,16 @@ parseWith p f s = case runParser (whole p) f s of
                     Right e  -> e
 
 mkErrors :: ParseErrorBundle Text SourcePos -> FilePath -> Text -> [UserError]
-mkErrors b f s = [ let (r, c) = lineCol s (errorOffset e) in mkError (parseErrorPretty e) (posSpan (SourcePos f (mkPos r) (mkPos c))) | e <- NE.toList (bundleErrors b)]
+mkErrors b f s = [ let (l, c) = lineCol s (errorOffset e) in mkError (parseErrorPretty e) (span l c) | e <- NE.toList (bundleErrors b)]
+  where
+    span l c = posSpan (SourcePos f (mkPos l) (mkPos c))
 
 -- PosState looks relevant for finding line/column, but I (Justin) don't know how to use it
 
 lineCol :: String -> Int -> (Int, Int)
 lineCol s i = foldl f (1, 1) (Prelude.take i s)
   where
-    f (r, c) char = if char == '\n' then (r + 1, 1) else (r, c + 1)
+    f (l, c) char = if char == '\n' then (l + 1, 1) else (l, c + 1)
 
 instance ShowErrorComponent SourcePos where
   showErrorComponent = show

--- a/src/Language/Elsa/Parser.hs
+++ b/src/Language/Elsa/Parser.hs
@@ -29,9 +29,9 @@ parseWith p f s = case runParser (whole p) f s of
                     Right e  -> e
 
 mkErrors :: ParseErrorBundle Text SourcePos -> FilePath -> Text -> [UserError]
-mkErrors b f s = [ let (l, c) = lineCol s (errorOffset e) in mkError (parseErrorPretty e) (span l c) | e <- NE.toList (bundleErrors b)]
+mkErrors b f s = [ mkError (parseErrorPretty e) (span e) | e <- NE.toList (bundleErrors b)]
   where
-    span l c = posSpan (SourcePos f (mkPos l) (mkPos c))
+    span e = let (l, c) = lineCol s (errorOffset e) in posSpan (SourcePos f (mkPos l) (mkPos c))
 
 -- PosState looks relevant for finding line/column, but I (Justin) don't know how to use it
 


### PR DESCRIPTION
Fixes #13. This input:

```haskell
let THD3   = \t -> t \x y z -> z
```

...now produces the following error message:

```
Errors found!
foo.lc:1:22-22: offset=21:
unexpected '\'
expecting "eval", "let", or end of input


         1|  let THD3   = \t -> t \x y z -> z
                                  


**** Errors found! *************************************************************
```

This is an improvement over the prior error message, which would show a row and column of 1:

```
Errors found!
foo.lc:1:1-1: offset=21:
...
```

I also tested this with parse errors on lines greater than 1. I'm open to feedback on code structure/style!