### PR TITLE
Update to ghc 9.4.7

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-18.28
-compiler: ghc-8.10.7
+resolver: lts-21.13
+compiler: ghc-9.4.7
 allow-newer: true
 packages:
 - '.'


### PR DESCRIPTION
This is the fix several students in the class have used to get elsa to compile on Apple silicon.