### PR TITLE
Add WebAssembly option

### DIFF
--- a/src/Language/Elsa/Eval.hs
+++ b/src/Language/Elsa/Eval.hs
@@ -7,9 +7,11 @@ import qualified Data.HashMap.Lazy    as ML
 import qualified Data.HashSet         as S
 import qualified Data.List            as L
 import           Control.Monad.State
+import           Control.Monad        (foldM)
 import qualified Data.Maybe           as Mb -- (isJust, maybeToList)
 import           Language.Elsa.Types
 import           Language.Elsa.Utils  (qPushes, qInit, qPop, fromEither)
+
 
 --------------------------------------------------------------------------------
 elsa :: Elsa a -> [Result a]

--- a/src/Language/Elsa/UX.hs
+++ b/src/Language/Elsa/UX.hs
@@ -181,6 +181,7 @@ data Mode
   = Json
   | Cmdline
   | Server
+  | Wasm
   deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
@@ -218,6 +219,7 @@ renderErrors :: Mode -> [UserError] -> IO Text
 renderErrors Json    es = return (renderErrorsJson es)
 renderErrors Server  es = return (renderResultJson es)
 renderErrors Cmdline es = renderErrorsText es
+renderErrors Wasm    es = renderErrorsText es
 
 renderErrorsText :: [UserError] -> IO Text
 renderErrorsText [] =


### PR DESCRIPTION
This PR implements web assembly option so that Elsa can evaluate in the main thread and handle timeout from the web page. I just took CSE 130 this quarter so let me know if there is a better way to handle this case in Haskell 😅 

You can find the static website [here](https://elsa-web-wasm.pages.dev/) and [the repository](https://github.com/edykim/elsa-web-wasm) which contains elsa.wasm with this change. It does not have a saving on server feature, but it is very responsive since it works on web browser alone.

I've learned a lot about functional programming and lambda calculus with Elsa. Thanks for creating such a cool language!